### PR TITLE
Better VLC detection, choose installation directory if no VLC was found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /target/
 /*.iml
 .pmd
+.eclipse-pmd

--- a/.project
+++ b/.project
@@ -25,11 +25,17 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>ch.acanda.eclipse.pmd.builder.PMDBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>net.sourceforge.pmd.eclipse.plugin.pmdNature</nature>
+		<nature>ch.acanda.eclipse.pmd.builder.PMDNature</nature>
 	</natures>
 </projectDescription>

--- a/src/main/java/nl/tudelft/contextproject/ContextTFP.java
+++ b/src/main/java/nl/tudelft/contextproject/ContextTFP.java
@@ -45,6 +45,7 @@ import java.util.List;
  */
 public class ContextTFP extends Application {
     
+    private static boolean hasVLC;
     private static BorderPane rootLayout;
     private static Script script;
 
@@ -122,7 +123,14 @@ public class ContextTFP extends Application {
      */
     public void initVLCj() {
         if (!new NativeDiscovery().discover()) {
-            AlertDialog.errorVlcNotFound(primaryStage);
+            try {
+                AlertDialog.errorVlcNotFound(primaryStage);
+                hasVLC = true;
+            } catch (RuntimeException e) {
+                hasVLC = false;
+            }
+        } else {
+            hasVLC = true;
         }
     }
 
@@ -169,5 +177,9 @@ public class ContextTFP extends Application {
      */
     public static BorderPane getRootLayout() {
         return rootLayout;
+    }
+    
+    public static boolean hasVLC() {
+        return hasVLC;
     }
 }

--- a/src/main/java/nl/tudelft/contextproject/ContextTFP.java
+++ b/src/main/java/nl/tudelft/contextproject/ContextTFP.java
@@ -14,14 +14,18 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
+
 import nl.tudelft.contextproject.camera.Camera;
 import nl.tudelft.contextproject.camera.CameraSettings;
 import nl.tudelft.contextproject.camera.LiveCameraConnection;
 import nl.tudelft.contextproject.camera.MockedCameraConnection;
+import nl.tudelft.contextproject.gui.AlertDialog;
 import nl.tudelft.contextproject.gui.MenuController;
 import nl.tudelft.contextproject.presets.InstantPreset;
 import nl.tudelft.contextproject.script.Script;
 import nl.tudelft.contextproject.script.Shot;
+
+import uk.co.caprica.vlcj.discovery.NativeDiscovery;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +44,7 @@ import java.util.List;
  * @since 0.1
  */
 public class ContextTFP extends Application {
-
+    
     private static BorderPane rootLayout;
     private static Script script;
 
@@ -86,6 +90,7 @@ public class ContextTFP extends Application {
         }
 
         initRootLayout();
+        Platform.runLater(() -> initVLCj());
         MenuController.show();
     }
 
@@ -107,6 +112,17 @@ public class ContextTFP extends Application {
             });
         } catch (IOException e) {
             e.printStackTrace();
+        }
+    }
+    
+    /**
+     * Tries to load VLC using the VLC native discovery tactic.
+     * If it cannot find VLC installed, it will ask for the location of the
+     * VLC installation.
+     */
+    public void initVLCj() {
+        if (!new NativeDiscovery().discover()) {
+            AlertDialog.errorVlcNotFound(primaryStage);
         }
     }
 

--- a/src/main/java/nl/tudelft/contextproject/gui/LiveStreamHandler.java
+++ b/src/main/java/nl/tudelft/contextproject/gui/LiveStreamHandler.java
@@ -17,6 +17,8 @@ import uk.co.caprica.vlcj.player.direct.format.RV32BufferFormat;
 
 import java.nio.ByteBuffer;
 
+import nl.tudelft.contextproject.ContextTFP;
+
 /**
  * Handler for streaming media into the GUI through VLC.
  * 
@@ -46,15 +48,19 @@ public class LiveStreamHandler {
      * Starts playing the media.
      */
     public void start() {
-        mediaPlayer.getMediaPlayer().playMedia(streamLink);
+        if (mediaPlayer != null) {
+            mediaPlayer.getMediaPlayer().playMedia(streamLink);
+        }
     }
     
     /**
      * Stops playing the media and release associated resources.
      */
     public void stop() {
-        mediaPlayer.getMediaPlayer().stop();
-        mediaPlayer.getMediaPlayer().release();
+        if (mediaPlayer != null) {
+            mediaPlayer.getMediaPlayer().stop();
+            mediaPlayer.getMediaPlayer().release();
+        }
     }
     
     /**
@@ -65,6 +71,9 @@ public class LiveStreamHandler {
      * @return a ImageView object displaying the stream.
      */
     public ImageView createImageView(String streamLink, double width, double height) {
+        if (!ContextTFP.hasVLC()) {
+            return createErrorImageView();
+        }
         WritableImage writableImage = new WritableImage((int) width, (int) height);
         imageView = new ImageView(writableImage);
         this.streamLink = streamLink;
@@ -89,6 +98,10 @@ public class LiveStreamHandler {
             }
         };
         return imageView;
+    }
+    
+    public ImageView createErrorImageView() {
+        return new ImageView("error.jpg");
     }
     
     /**

--- a/src/main/java/nl/tudelft/contextproject/gui/PresetController.java
+++ b/src/main/java/nl/tudelft/contextproject/gui/PresetController.java
@@ -77,10 +77,7 @@ public class PresetController {
      */
     private void applySettings() {
         vBox.setAlignment(Pos.CENTER);
-
         vBox.getChildren().clear();
-        
-        System.setProperty("jna.library.path", "C:\\Program Files\\VideoLAN\\VLC");
     }
     
     /**

--- a/src/main/java/nl/tudelft/contextproject/script/Script.java
+++ b/src/main/java/nl/tudelft/contextproject/script/Script.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Class to represent a Script of {@link Shot Shots}.


### PR DESCRIPTION
Using VLCj's VLC detection strategies, the app can now better detect if VLC is installed. When VLC cannot be found at startup, a file chooser opens and the path to VLC must be chosen, until a valid installation is found. Clicking cancel in the file chooser throws a RuntimeException for now, not sure if I should close down the app entirely or let the user continue. Continuing may give errors / exceptions, which would need fixing.
