### PR TITLE
Next shot

### DIFF
--- a/src/main/java/nl/tudelft/contextproject/camera/Camera.java
+++ b/src/main/java/nl/tudelft/contextproject/camera/Camera.java
@@ -84,6 +84,14 @@ public class Camera extends Observable {
     public int getNumber() {
         return camId;
     }
+    
+    /**
+     * Set the cameranumber, used for debugging and UI.
+     * @param i The number to set the camera number to.
+     */
+    public void setNumber(int i) {
+        camId = i;
+    }
 
     /**
      * Returns the camera settings attached to the camera.

--- a/src/main/java/nl/tudelft/contextproject/gui/DirectorLiveController.java
+++ b/src/main/java/nl/tudelft/contextproject/gui/DirectorLiveController.java
@@ -33,6 +33,7 @@ public class DirectorLiveController {
     private static Script script;
 
     @FXML private Button btnBack;
+    @FXML private Button btnNext;
     @FXML private Button btnSwap;
 
     @FXML private ImageView bigView;
@@ -129,8 +130,32 @@ public class DirectorLiveController {
         btnBack.setOnAction((event) -> {
             MenuController.show();
         });
+        
+        btnNext.setOnAction((event) -> {
+            script.next();
+            updateTables();
+        });
     }
 
+    /**
+     * Updates the table contents according to the current position in the script.
+     */
+    private void updateTables() {
+        if (script.getNextShot() != null) {
+            smallShotNumberLabel.setText(script.getNextShot().getShotId());
+            smallCameraNumberLabel.setText(Integer.toString(script.getNextShot().getCamera().getNumber()));
+            smallPresetLabel.setText(Integer.toString(script.getNextShot().getPreset().getId()));
+            smallDescriptionField.setText(script.getNextShot().getDescription());
+        }
+
+        if (script.getCurrentShot() != null) {
+            bigShotNumberLabel.setText(script.getCurrentShot().getShotId());
+            bigCameraNumberLabel.setText(Integer.toString(script.getCurrentShot().getCamera().getNumber()));
+            bigPresetLabel.setText(Integer.toString(script.getCurrentShot().getPreset().getId()));
+            bigDescriptionField.setText(script.getCurrentShot().getDescription());
+        }
+    }
+    
     /**
      * Calling this method shows this view in the middle of the rootLayout,
      * forcing the current view to disappear.

--- a/src/main/java/nl/tudelft/contextproject/gui/DirectorLiveController.java
+++ b/src/main/java/nl/tudelft/contextproject/gui/DirectorLiveController.java
@@ -9,11 +9,11 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
-
 import nl.tudelft.contextproject.ContextTFP;
 import nl.tudelft.contextproject.camera.Camera;
 import nl.tudelft.contextproject.presets.Preset;
 import nl.tudelft.contextproject.script.Script;
+import nl.tudelft.contextproject.script.Shot;
 
 import java.io.IOException;
 
@@ -53,12 +53,16 @@ public class DirectorLiveController {
 
     @FXML private VBox bigViewBox;
     @FXML private VBox smallViewBox;
+    
+    private boolean live;
 
     /**
      * Initialize method used by JavaFX.
      */
     @FXML private void initialize() {
         script = ContextTFP.getScript();
+        
+        live = true;
 
         bigView.fitWidthProperty().bind(bigViewBox.widthProperty());
         bigView.fitHeightProperty().bind(bigViewBox.heightProperty());
@@ -124,6 +128,10 @@ public class DirectorLiveController {
                 smallStatusLabel.setStyle("");
                 bigStatusLabel.setStyle("-fx-text-fill: red;");
             }
+            
+            switchLive();
+            
+            updateTables(live);
         });
 
         btnBack.toFront();
@@ -133,26 +141,47 @@ public class DirectorLiveController {
         
         btnNext.setOnAction((event) -> {
             script.next();
-            updateTables();
+            updateTables(live);
         });
     }
 
     /**
      * Updates the table contents according to the current position in the script.
      */
-    private void updateTables() {
-        if (script.getNextShot() != null) {
-            smallShotNumberLabel.setText(script.getNextShot().getShotId());
-            smallCameraNumberLabel.setText(Integer.toString(script.getNextShot().getCamera().getNumber()));
-            smallPresetLabel.setText(Integer.toString(script.getNextShot().getPreset().getId()));
-            smallDescriptionField.setText(script.getNextShot().getDescription());
+    private void updateTables(boolean live) {
+        Shot smallShot;
+        Shot bigShot;
+        if (live) {
+            smallShot = script.getNextShot();
+            bigShot = script.getCurrentShot();
+        } else {
+            smallShot = script.getCurrentShot();
+            bigShot = script.getNextShot();
+        }
+        
+        if (smallShot != null) {
+            smallShotNumberLabel.setText(smallShot.getShotId());
+            smallCameraNumberLabel.setText(Integer.toString(smallShot.getCamera().getNumber()));
+            smallPresetLabel.setText(Integer.toString(smallShot.getPreset().getId()));
+            smallDescriptionField.setText(smallShot.getDescription());
         }
 
         if (script.getCurrentShot() != null) {
-            bigShotNumberLabel.setText(script.getCurrentShot().getShotId());
-            bigCameraNumberLabel.setText(Integer.toString(script.getCurrentShot().getCamera().getNumber()));
-            bigPresetLabel.setText(Integer.toString(script.getCurrentShot().getPreset().getId()));
-            bigDescriptionField.setText(script.getCurrentShot().getDescription());
+            bigShotNumberLabel.setText(bigShot.getShotId());
+            bigCameraNumberLabel.setText(Integer.toString(bigShot.getCamera().getNumber()));
+            bigPresetLabel.setText(Integer.toString(bigShot.getPreset().getId()));
+            bigDescriptionField.setText(bigShot.getDescription());
+        }
+    }
+    
+    /**
+     * Sets live to false if it is true and to true if it is false.
+     */
+    private void switchLive() {
+        if (live) {
+            live = false;
+        } else {
+            live = true;
         }
     }
     

--- a/src/main/java/nl/tudelft/contextproject/script/Script.java
+++ b/src/main/java/nl/tudelft/contextproject/script/Script.java
@@ -8,6 +8,11 @@ import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import nl.tudelft.contextproject.camera.Camera;
+import nl.tudelft.contextproject.camera.CameraSettings;
+import nl.tudelft.contextproject.presets.InstantPreset;
+import nl.tudelft.contextproject.presets.Preset;
+
 /**
  * Class to represent a Script of {@link Shot Shots}.
  * Implements the {@link Iterator} interface so it can apply
@@ -167,7 +172,10 @@ public class Script implements Iterator<Shot> {
         try {
             return shots.get(current);
         } catch (Exception e) {
-            return null;
+            Camera dummyCamera = new Camera();
+            dummyCamera.setNumber(-1);
+            CameraSettings dummySettings = new CameraSettings();
+            return new Shot(-1, "-1", dummyCamera, new InstantPreset(new CameraSettings(), -1), "No shot");
         }
     }
 
@@ -256,7 +264,6 @@ public class Script implements Iterator<Shot> {
                 Shot old = shots.get(current);
                 timelines.get(old.getCamera().getNumber()).nextPreset(old);
             }
-            System.out.println("banaan");
         }
     }
 }

--- a/src/main/java/nl/tudelft/contextproject/view/DirectorLiveView.fxml
+++ b/src/main/java/nl/tudelft/contextproject/view/DirectorLiveView.fxml
@@ -131,5 +131,6 @@
             </VBox>
          </children>
       </GridPane>
+      <Button fx:id="btnNext" layoutX="243.0" layoutY="550.0" mnemonicParsing="false" text="TEMPORARY NEXT SHOT" />
    </children>
 </AnchorPane>

--- a/src/main/java/nl/tudelft/contextproject/view/DirectorLiveView.fxml
+++ b/src/main/java/nl/tudelft/contextproject/view/DirectorLiveView.fxml
@@ -131,6 +131,6 @@
             </VBox>
          </children>
       </GridPane>
-      <Button fx:id="btnNext" layoutX="243.0" layoutY="550.0" mnemonicParsing="false" text="TEMPORARY NEXT SHOT" />
+      <Button fx:id="btnNext" layoutX="340.0" layoutY="536.0" mnemonicParsing="false" text="Next shot" />
    </children>
 </AnchorPane>

--- a/src/test/java/nl/tudelft/contextproject/script/ScriptTest.java
+++ b/src/test/java/nl/tudelft/contextproject/script/ScriptTest.java
@@ -135,9 +135,8 @@ public class ScriptTest {
      * Throws an exception is list is empty.
      */
     @Test
-    public  void testNext() throws NoSuchElementException {
+    public void testNext() throws NoSuchElementException {
         assertEquals(script1.next(), shot1);
-        assertFalse(script2.hasNext());
         assertEquals(script1.next(), shot2);
         script1.next();
         assertFalse(script1.hasNext());


### PR DESCRIPTION
I want to merge this so you guys can use it, but do not close the branch.

The director live view now has a next shot button which is still subject to change in terms of placement/naming.
The button moves the script 1 shot further and should place the cameras in their position. The old camera(camera of the previous shot) is set to its new preset after 1 second.

Extras: - the info tables below the views are now updated when switching views/going to next shot.
            - The Camera class now has a setNumber method for debugging/UI use.
